### PR TITLE
Fix bad issue URL

### DIFF
--- a/2018-04-14-mgba-0.6.3.md
+++ b/2018-04-14-mgba-0.6.3.md
@@ -14,6 +14,6 @@ Bugfixes:
 
  - GB Audio: Revert unsigned audio changes
  - GB Video: Fix bad merge (fixes [#1040](https://mgba.io/i/1040))
- - GBA Video: Fix OBJ blending regression (fixes [#1037](mgba.io/i/1037))
+ - GBA Video: Fix OBJ blending regression (fixes [#1037](https://mgba.io/i/1037))
 
 Get it now in the [Downloads]({{ site.baseurl }}/downloads.html) section. Binaries are available for Windows, Ubuntu, macOS, 3DS, Vita, and Wii, and the source code is available for all other platforms.


### PR DESCRIPTION
Currently links to https://mgba.io/2018/04/14/mgba-0.6.3/mgba.io/i/1037 instead on the website, which isn't right.